### PR TITLE
Add persistent model cache and worker reuse

### DIFF
--- a/src/llama-mt/llama.js
+++ b/src/llama-mt/llama.js
@@ -11,41 +11,63 @@ class LlamaCpp {
     }
     
     loadWorker() {
-        this.worker = new Worker(
-            new URL("./main-worker.js", import.meta.url),
-            {type: "module"}
-        );
-        
-        this.worker.onmessage = (event) => {
-            switch (event.data.event) {
-                case action.INITIALIZED:
-                    // Load Model
-                    if (this.init_callback) {
-                        this.init_callback();
-                    }
+        if (!globalThis.__llamaWorkerCache) {
+            globalThis.__llamaWorkerCache = {};
+        }
 
-                    break;
-                case action.WRITE_RESULT:
-                    // Capture result
-                    if (this.write_result_callback) {
-                        this.write_result_callback(event.data.text);
-                    }
-
-                    break;
-                case action.RUN_COMPLETED:
-                    // Execution Completed
-                    if (this.on_complete_callback) {
-                        this.on_complete_callback();
-                    }
-                    
-                    break;
+        const cached = globalThis.__llamaWorkerCache[this.url];
+        if (cached) {
+            this.worker = cached.worker;
+            cached.listeners.add(this);
+            this.attachHandler(cached);
+            if (cached.initialized && this.init_callback) {
+                Promise.resolve().then(() => this.init_callback());
             }
+            return;
+        }
+
+        const worker = new Worker(
+            new URL("./main-worker.js", import.meta.url),
+            { type: "module" }
+        );
+        this.worker = worker;
+        globalThis.__llamaWorkerCache[this.url] = {
+            worker,
+            initialized: false,
+            listeners: new Set([this])
         };
+        this.attachHandler(globalThis.__llamaWorkerCache[this.url]);
 
         this.worker.postMessage({
             event: action.LOAD,
             url: this.url,
         });
+    }
+
+    attachHandler(cacheEntry) {
+        const handler = (event) => {
+            switch (event.data.event) {
+                case action.INITIALIZED:
+                    cacheEntry.initialized = true;
+                    if (this.init_callback) {
+                        this.init_callback();
+                    }
+                    break;
+                case action.WRITE_RESULT:
+                    if (this.write_result_callback) {
+                        this.write_result_callback(event.data.text);
+                    }
+                    break;
+                case action.RUN_COMPLETED:
+                    if (this.on_complete_callback) {
+                        this.on_complete_callback();
+                    }
+                    break;
+            }
+        };
+
+        cacheEntry.worker.addEventListener('message', handler);
+        this._handler = handler;
     }
 
     run({
@@ -73,6 +95,16 @@ class LlamaCpp {
             top_p,
             no_display_prompt,
         });
+    }
+
+    dispose() {
+        if (this.worker && this._handler) {
+            this.worker.removeEventListener('message', this._handler);
+            const cache = globalThis.__llamaWorkerCache?.[this.url];
+            if (cache) {
+                cache.listeners.delete(this);
+            }
+        }
     }
 }
 

--- a/src/llama-mt/main-worker.js
+++ b/src/llama-mt/main-worker.js
@@ -4,6 +4,7 @@ import Module from "./main.js";
 
 // WASM Module
 let module;
+let modelLoaded = false;
 
 // hard-coded filepath for loaded model in vfs
 const model_path = "/models/model.bin";
@@ -41,6 +42,11 @@ const stdout = (c) => {
 const stderr = () => {};
 
 const initWorker = async (modelPath) => {
+    if (module && modelLoaded) {
+        postMessage({ event: action.INITIALIZED });
+        return;
+    }
+
     const emscrModule = {
         noInitialRun: true,
         preInit: [() => {
@@ -68,7 +74,9 @@ const initWorker = async (modelPath) => {
 
         // load model
         module['FS_createDataFile']('/models', 'model.bin', bytes, true, true, true);
-        
+
+        modelLoaded = true;
+
         // update callback action to worker main thread
         postMessage({
             event: action.INITIALIZED

--- a/src/llama-mt/utility.js
+++ b/src/llama-mt/utility.js
@@ -1,39 +1,102 @@
 const cacheName = "llama-cpp-wasm-cache";
+const dbName = "llama-cpp-models";
+const storeName = "models";
+
+function openDB() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName, 1);
+        req.onupgradeneeded = () => {
+            req.result.createObjectStore(storeName);
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function getFromDB(db, key) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readonly");
+        const store = tx.objectStore(storeName);
+        const g = store.get(key);
+        g.onsuccess = () => resolve(g.result);
+        g.onerror = () => reject(g.error);
+    });
+}
+
+async function saveToDB(db, key, buffer) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
+        const store = tx.objectStore(storeName);
+        const p = store.put(buffer, key);
+        p.onsuccess = () => resolve();
+        p.onerror = () => reject(p.error);
+    });
+}
 
 export async function loadBinaryResource(url, callback) {
-    let cache = null, window = self;
+    let cache = null;
 
-    // Try to find if the model data is cached in Web Worker memory.
-    if (typeof window === "undefined") {
-        console.debug("`window` is not defined");
-    } else if (window && window.caches) {
-        cache = await window.caches.open(cacheName);
+    if (!self.cachedModels) {
+        self.cachedModels = {};
+    }
+
+    if (self.cachedModels[url]) {
+        callback(self.cachedModels[url]);
+        return;
+    }
+
+    let db;
+    if (self.indexedDB) {
+        try {
+            db = await openDB();
+            const stored = await getFromDB(db, url);
+            if (stored) {
+                const byteArray = new Uint8Array(stored);
+                self.cachedModels[url] = byteArray;
+                callback(byteArray);
+                return;
+            }
+        } catch (e) {
+            console.error("IndexedDB load error", e);
+        }
+    }
+
+    if (self.caches) {
+        cache = await self.caches.open(cacheName);
         const cachedResponse = await cache.match(url);
 
         if (cachedResponse) {
             const data = await cachedResponse.arrayBuffer();
             const byteArray = new Uint8Array(data);
+            self.cachedModels[url] = byteArray;
+
+            if (db) {
+                saveToDB(db, url, data).catch(() => {});
+            }
+
             callback(byteArray);
             return;
         }
     }
-
 
     // Download model and store in cache
     const req = new XMLHttpRequest();
     req.open("GET", url, true);
     req.responseType = "arraybuffer";
 
-    req.onload = async (_) => {
-        const arrayBuffer = req.response; // Note: not req.responseText
-        
+    req.onload = async () => {
+        const arrayBuffer = req.response;
         if (arrayBuffer) {
             const byteArray = new Uint8Array(arrayBuffer);
-            
-            if (cache) {
-                await cache.put(url, new Response(arrayBuffer))
-            };
 
+            if (cache) {
+                await cache.put(url, new Response(arrayBuffer));
+            }
+            if (db) {
+                saveToDB(db, url, arrayBuffer).catch(() => {});
+            }
+
+            self.cachedModels[url] = byteArray;
             callback(byteArray);
         }
     };

--- a/src/llama-st/llama.js
+++ b/src/llama-st/llama.js
@@ -11,41 +11,64 @@ class LlamaCpp {
     }
     
     loadWorker() {
-        this.worker = new Worker(
-            new URL("./main-worker.js", import.meta.url),
-            {type: "module"}
-        );
-        
-        this.worker.onmessage = (event) => {
-            switch (event.data.event) {
-                case action.INITIALIZED:
-                    // Load Model
-                    if (this.init_callback) {
-                        this.init_callback();
-                    }
+        if (!globalThis.__llamaWorkerCache) {
+            globalThis.__llamaWorkerCache = {};
+        }
 
-                    break;
-                case action.WRITE_RESULT:
-                    // Capture result
-                    if (this.write_result_callback) {
-                        this.write_result_callback(event.data.text);
-                    }
-
-                    break;
-                case action.RUN_COMPLETED:
-                    // Execution Completed
-                    if (this.on_complete_callback) {
-                        this.on_complete_callback();
-                    }
-                    
-                    break;
+        const cached = globalThis.__llamaWorkerCache[this.url];
+        if (cached) {
+            this.worker = cached.worker;
+            cached.listeners.add(this);
+            this.attachHandler(cached);
+            if (cached.initialized && this.init_callback) {
+                // ensure async callback so event handlers are attached
+                Promise.resolve().then(() => this.init_callback());
             }
+            return;
+        }
+
+        const worker = new Worker(
+            new URL("./main-worker.js", import.meta.url),
+            { type: "module" }
+        );
+        this.worker = worker;
+        globalThis.__llamaWorkerCache[this.url] = {
+            worker,
+            initialized: false,
+            listeners: new Set([this])
         };
+        this.attachHandler(globalThis.__llamaWorkerCache[this.url]);
 
         this.worker.postMessage({
             event: action.LOAD,
             url: this.url,
         });
+    }
+
+    attachHandler(cacheEntry) {
+        const handler = (event) => {
+            switch (event.data.event) {
+                case action.INITIALIZED:
+                    cacheEntry.initialized = true;
+                    if (this.init_callback) {
+                        this.init_callback();
+                    }
+                    break;
+                case action.WRITE_RESULT:
+                    if (this.write_result_callback) {
+                        this.write_result_callback(event.data.text);
+                    }
+                    break;
+                case action.RUN_COMPLETED:
+                    if (this.on_complete_callback) {
+                        this.on_complete_callback();
+                    }
+                    break;
+            }
+        };
+
+        cacheEntry.worker.addEventListener('message', handler);
+        this._handler = handler;
     }
 
     run({
@@ -73,6 +96,16 @@ class LlamaCpp {
             top_p,
             no_display_prompt,
         });
+    }
+
+    dispose() {
+        if (this.worker && this._handler) {
+            this.worker.removeEventListener('message', this._handler);
+            const cache = globalThis.__llamaWorkerCache?.[this.url];
+            if (cache) {
+                cache.listeners.delete(this);
+            }
+        }
     }
 }
 

--- a/src/llama-st/main-worker.js
+++ b/src/llama-st/main-worker.js
@@ -4,6 +4,7 @@ import Module from "./main.js";
 
 // WASM Module
 let module;
+let modelLoaded = false;
 
 // hard-coded filepath for loaded model in vfs
 const model_path = "/models/model.bin";
@@ -41,6 +42,11 @@ const stdout = (c) => {
 const stderr = () => {};
 
 const initWorker = async (modelPath) => {
+    if (module && modelLoaded) {
+        postMessage({ event: action.INITIALIZED });
+        return;
+    }
+
     const emscrModule = {
         noInitialRun: true,
         preInit: [() => {
@@ -68,7 +74,9 @@ const initWorker = async (modelPath) => {
 
         // load model
         module['FS_createDataFile']('/models', 'model.bin', bytes, true, true, true);
-        
+
+        modelLoaded = true;
+
         // update callback action to worker main thread
         postMessage({
             event: action.INITIALIZED

--- a/src/llama-st/utility.js
+++ b/src/llama-st/utility.js
@@ -1,39 +1,102 @@
 const cacheName = "llama-cpp-wasm-cache";
+const dbName = "llama-cpp-models";
+const storeName = "models";
+
+function openDB() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName, 1);
+        req.onupgradeneeded = () => {
+            req.result.createObjectStore(storeName);
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function getFromDB(db, key) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readonly");
+        const store = tx.objectStore(storeName);
+        const g = store.get(key);
+        g.onsuccess = () => resolve(g.result);
+        g.onerror = () => reject(g.error);
+    });
+}
+
+async function saveToDB(db, key, buffer) {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, "readwrite");
+        const store = tx.objectStore(storeName);
+        const p = store.put(buffer, key);
+        p.onsuccess = () => resolve();
+        p.onerror = () => reject(p.error);
+    });
+}
 
 export async function loadBinaryResource(url, callback) {
-    let cache = null, window = self;
+    let cache = null;
 
-    // Try to find if the model data is cached in Web Worker memory.
-    if (typeof window === "undefined") {
-        console.debug("`window` is not defined");
-    } else if (window && window.caches) {
-        cache = await window.caches.open(cacheName);
+    if (!self.cachedModels) {
+        self.cachedModels = {};
+    }
+
+    if (self.cachedModels[url]) {
+        callback(self.cachedModels[url]);
+        return;
+    }
+
+    let db;
+    if (self.indexedDB) {
+        try {
+            db = await openDB();
+            const stored = await getFromDB(db, url);
+            if (stored) {
+                const byteArray = new Uint8Array(stored);
+                self.cachedModels[url] = byteArray;
+                callback(byteArray);
+                return;
+            }
+        } catch (e) {
+            console.error("IndexedDB load error", e);
+        }
+    }
+
+    if (self.caches) {
+        cache = await self.caches.open(cacheName);
         const cachedResponse = await cache.match(url);
 
         if (cachedResponse) {
             const data = await cachedResponse.arrayBuffer();
             const byteArray = new Uint8Array(data);
+            self.cachedModels[url] = byteArray;
+
+            if (db) {
+                saveToDB(db, url, data).catch(() => {});
+            }
+
             callback(byteArray);
             return;
         }
     }
-
 
     // Download model and store in cache
     const req = new XMLHttpRequest();
     req.open("GET", url, true);
     req.responseType = "arraybuffer";
 
-    req.onload = async (_) => {
-        const arrayBuffer = req.response; // Note: not req.responseText
-        
+    req.onload = async () => {
+        const arrayBuffer = req.response;
         if (arrayBuffer) {
             const byteArray = new Uint8Array(arrayBuffer);
-            
-            if (cache) {
-                await cache.put(url, new Response(arrayBuffer))
-            };
 
+            if (cache) {
+                await cache.put(url, new Response(arrayBuffer));
+            }
+            if (db) {
+                saveToDB(db, url, arrayBuffer).catch(() => {});
+            }
+
+            self.cachedModels[url] = byteArray;
             callback(byteArray);
         }
     };


### PR DESCRIPTION
## Summary
- cache loaded model bytes in IndexedDB and the browser cache
- keep workers alive across `LlamaCpp` instances
- reuse existing worker if the same model is requested

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847a8da7fc48330b8d5ececf604d5cd