### PR TITLE
Fix vite dev server entry path

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script type="module" crossorigin src="/client-side-free-ai/assets/index-CBGVEeNF.js"></script>
-    <link rel="stylesheet" crossorigin href="/client-side-free-ai/assets/index-DNrsL-t8.css">
+    <script type="module" src="/client-side-free-ai/src/main.jsx"></script>
   </head>
   <body>
-    <div id="root"></div>
+</html>
+
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix `index.html` to point to `/src/main.jsx` instead of built assets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cb19a4708330bf8ff45fc5b61b17